### PR TITLE
Veteran Cost Modifier and Showing Kerbals' Names

### DIFF
--- a/GameData/TRP-Hire/localization/en-us.cfg
+++ b/GameData/TRP-Hire/localization/en-us.cfg
@@ -8,10 +8,12 @@ Localization
 		#TRPHire_Button_Hire           = Hire Applicant
 		#TRPHire_Button_NotEnoughFunds = Not Enough Funds!
 		#TRPHire_Button_RosterFull     = Roster is Full!
+		#TRPHire_Button_NameConflict   = Namesake Alert!
 
 		#TRPHire_BulkHireNo =  Bulk hire Option: You can not hire any more kerbals at this time!
 		#TRPHire_BulkHireSelector = Bulk hire Selector
 		#TRPHire_IsFearless = Is this Kerbal Fearless?
+		#TRPHire_IsVeteran = Is this Kerbal likes orange?
 
 		#TRPHire_SelectLevel = Select Kerbal's Level:
 		#TRPHire_Level5CareerNoExp = Level 5 - Mandatory for Career with no EXP enabled.
@@ -45,6 +47,8 @@ Localization
 		#TRPHire_Settings_GenderTooltip =  The privilege of selecting the sex costs kredits
 		#TRPHire_Settings_Fearless =  Fearless Cost Modifier
 		#TRPHire_Settings_FearlessTooltip =  Fearless kerbals get a higher pay, based on this value.
+		#TRPHire_Settings_Veteran = Orange Suit Cost Modifier
+		#TRPHire_Settings_VeteranTooltip = "Orange suit" gets a higher pay, based on this value.
 		#TRPHire_Settings_LevelUp =  LevelUp Cost Modifier
 		#TRPHire_Settings_LevelUpTooltip =  More skilled kerbals get a higher pay, based on this value.
 

--- a/GameData/TRP-Hire/localization/ru.cfg
+++ b/GameData/TRP-Hire/localization/ru.cfg
@@ -8,18 +8,20 @@ Localization
 		#TRPHire_Button_Hire           = Нанять
 		#TRPHire_Button_NotEnoughFunds = Недостаточно средств!
 		#TRPHire_Button_RosterFull     = Центр кербонавтов заполнен!
+		#TRPHire_Button_NameConflict   = Конфликт имени: тёзка
 
 		#TRPHire_BulkHireNo =  Сейчас вы не сможете нанять больше кербалов
 		#TRPHire_BulkHireSelector = Кол-во кербалов
 
 		#TRPHire_IsFearless = Этот кербал бесстрашен?
+		#TRPHire_IsVeteran = Оранжевый — хит сезона?
 
 		#TRPHire_SelectLevel = Выбрать уровень кербала:
 		#TRPHire_Level5CareerNoExp      = При выключенном опыте кербонавтов только 5 уровень.
 		#TRPHire_Level5SandboxOrScience = Для режимов «Песочница» и «Наука» только 5 уровень.
 
 		#TRPHire_MaxDiscount =  Максимальная скидка <<1>>% достигнута!
-		#TRPHire_NewYear = С Новым Годом!
+		#TRPHire_NewYear = С Новым годом!
 		#TRPHire_BlackMunday = День скидок «Black Munday»!
 		#TRPHire_YourDiscount = Ваша скидка <<1>>%
 		#TRPHire_TotalCost = Итоговая стоимость: <<1>>
@@ -46,8 +48,10 @@ Localization
 		#TRPHire_Settings_GenderTooltip =  За возможность нанять кербала определённого пола теперь нужно платить.\nЭтот модификатор покажет во сколько раз больше.
 		#TRPHire_Settings_Fearless =  Сорвиголова
 		#TRPHire_Settings_FearlessTooltip =  Бесстрашные кербалы стоят в столько раз больше.
+		#TRPHire_Settings_Veteran = Ветеран
+		#TRPHire_Settings_VeteranTooltip = Ветераны в оранжевых скафандрах стоят в столько раз больше.
 		#TRPHire_Settings_LevelUp =  Начальное повышение уровня
-		#TRPHire_Settings_LevelUpTooltip =  Если центр кербонавтов достаточно улучшен, то можно нанимать кербалов до 2го уровня,\nоднако для этого придётся раскошелиться. Этот модификатор покажет сколько стоит каждый новый уровень.
+		#TRPHire_Settings_LevelUpTooltip =  Если «центр кербонавтов» достаточно улучшен,\nто можно нанимать кербалов до 2го уровня,\nоднако для этого придётся раскошелиться.\nЭтот модификатор покажет сколько стоит каждый новый уровень.
 
 		#TRPHire_Settings_Panel3Title = Скидки
 		#TRPHire_Settings_Bulk5 = Малая оптовая скидка (%)
@@ -57,7 +61,7 @@ Localization
 		#TRPHire_Settings_Black = День скидок (%)
 		#TRPHire_Settings_BlackTooltip = Скидка во время «Black Munday». Всекербальский день скидок случается во время полного затмения.
 		#TRPHire_Settings_NewYear = Новогодняя скидка (%)
-		#TRPHire_Settings_NewYearTooltip = За 3 дня до конца года кербалы начинают отмечать Новый Год. В центре занятости большая скидка.
+		#TRPHire_Settings_NewYearTooltip = За 3 дня до конца года кербалы начинают отмечать Новый год. В центре занятости большая скидка.
 		#TRPHire_Settings_Maximum = Максимальная скидка (%)
 		#TRPHire_Settings_MaximumTooltip = Все скидки суммируются, но не могут превысить данного значения.
 	}

--- a/Hire/Settings.cs
+++ b/Hire/Settings.cs
@@ -110,6 +110,10 @@ namespace Hire
             toolTip = "#TRPHire_Settings_FearlessTooltip")]
         public double fearless_coef = 2f;
 
+        [GameParameters.CustomFloatParameterUI("#TRPHire_Settings_Veteran", minValue = 5.0f, maxValue = 15f, displayFormat = "N1",
+    toolTip = "#TRPHire_Settings_VeteranTooltip")]
+        public double veteran_coef = 10f;
+
         [GameParameters.CustomFloatParameterUI("#TRPHire_Settings_LevelUp", minValue = 0.0f, maxValue = 3f, displayFormat = "N2",
             toolTip = "#TRPHire_Settings_LevelUpTooltip")]
         public double levelup_coef = 1f;
@@ -118,11 +122,8 @@ namespace Hire
         public override void SetDifficultyPreset(GameParameters.Preset preset)
         {
             DefaultSettings = false;
-#if false
-            low_quality = 0.5f;
-            high_quality = 2f;
-#endif
             fearless_coef = 2f;
+            veteran_coef = 10f;
             gender_coef = 1.25f;
             levelup_coef = 1f;
         }


### PR DESCRIPTION
Veteran Cost Modifier (Orange Suit)
Showing Kerbals' names. (and possibility to rename them).
ban namesake purchase.

Clarification is needed for the last one.
if you allow a resurrection at settings, then the dead Bob Kerman moves from Missing to Available after restart, correct? Then it's ok.
But if the dead somehow could appear at stock game in Applicants list for purchasing, they would be renamed.


![screenshot0](https://user-images.githubusercontent.com/12796450/34361396-c7fcb76c-ea7a-11e7-83b2-366a910d2cad.png)