### PR TITLE
Trait-related refactoring and fixes

### DIFF
--- a/Hire/CustomAstronautComplexUI.cs
+++ b/Hire/CustomAstronautComplexUI.cs
@@ -128,12 +128,12 @@ namespace Hire
                     default: break;
                 }
 
-                string career = traits.KCareerStrings[KCareer];
+                string career = traits.traitTitles[KCareer].name;
                 // Sets the kerbal's career based on the KCareer switch.
                 KerbalRoster.SetExperienceTrait(newKerb, career);
 
                 // Hire.Log.Info("KSI :: KIA MIA Stat is: " + KDead);
-                // Hire.Log.Info("KSI :: " + newKerb.experienceTrait.TypeName + " " + newKerb.name + " has been created in: " + loopcount.ToString() + " loops.");
+                // Hire.Log.Info("KSI :: " + newKerb.experienceTrait.Config.Name + " " + newKerb.name + " has been created in: " + loopcount.ToString() + " loops.");
                 newKerb.rosterStatus = ProtoCrewMember.RosterStatus.Available;
                 newKerb.experience = 0;
                 newKerb.experienceLevel = 0;
@@ -375,14 +375,14 @@ namespace Hire
             {
                 if (kerbal.rosterStatus == ProtoCrewMember.RosterStatus.Dead)
                 {
-                    if (kerbal.experienceTrait.Title == traits.KCareerStrings[KCareer])
+                    if (kerbal.experienceTrait.Config.Name == traits.traitTitles[KCareer].name)
                     {
                         KDead += 1;
                     }
                 }
                 if (kerbal.rosterStatus == ProtoCrewMember.RosterStatus.Missing)
                 {
-                    if (kerbal.experienceTrait.Title == traits.KCareerStrings[KCareer])
+                    if (kerbal.experienceTrait.Config.Name == traits.traitTitles[KCareer].name)
                     {
                         KDead += 0.5;
                     }
@@ -422,7 +422,7 @@ namespace Hire
 
                 // Career selection
                 GUILayout.BeginVertical("box");
-                KCareer = GUILayout.SelectionGrid(KCareer, traits.KCareerGrid, traits.KCareerCnt);
+                KCareer = GUILayout.SelectionGrid(KCareer, traits.KCareerGrid, traits.KCareerPerRow);
                 // Adding a section for 'number/bulk hire' here using the int array kBulk 
                 if (cbulktest() < 1)
                 {


### PR DESCRIPTION

`Traits.cs`
* obtain traits' name (id) & title (display) from `ExperienceConfig`s already present in `GameDatabase` instead of fetching raw from config nodes
* remove special case handling that excludes "Unknown"; this probably being leftover artifact from previous attempt that parsed data from CommunityTraitIcons' config file and thus no longer needed
* store `traitTitles` as List instead of Dictionary
* remove redundant `KCareerStrings`
* rename `KCareerCnt` to `KCareerPerRow` for clarity: this is the number of careers to show per line of the `SelectionGrid` and _not_ the number of careers installed in the game
* fix `KCareerGrid` size to number of careers instead of incorrect `KCareerCnt`, for loop counter fixed to match
* remove unnecessary localization code. `TraitTitle.title` is already localized (if localization is available) when we obtain it

`CustomAstronautComplexUI.cs`
* updated to account for changes in `Traits.cs`
* use identifiers instead of display strings for checking `ProtoCrewMember`'s trait 
* use `pcm.experienceTrait.Config.Name` instead of `pcm.experienceTrait.TypeName` and `pcm.experienceTrait.Title`. See [here](https://github.com/cake-pie/CommunityTraitIcons/wiki/Obtaining-a-Kerbal's-specialization-class-type-(ExperienceTrait-name)) for info.
