### PR TITLE
Randomize stats on bulk hires

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,15 @@
-﻿0.6.9.1
+0.6.9.2
+	Thanks to @TonkaCrash for this:
+	CustomAstronautComplexUI.cs
+		Changed limit of hires to a single constant, was just set to 10 in various places, but logic assumed more than 10 could be hired at a time
+		
+		Randomized stats on bulkhires. Sliders affect average value of stats, 5% chance of a badass. Veteran and Badass buttons are ignored for bulkhires. 
+		
+		*** Issue *** If bulk slider > 1 badass and veteran buttons should be disabled, but for now they are just ignored by the code.
+	en-us.cfg
+		Fixed grammar in Veteran tooltip.
+
+0.6.9.1
 	Thanks to @TonkaCrash for this:
 		Fixed scaling issue
 


### PR DESCRIPTION
This adds a randomizer function for stats centered on the slider value with a 5% chance of Fearless. Veterans cannot be bulk hired. They need individual interviews. Cost is a flat rate regardless of the actual stats. Hiring in bulk give you a discount, but you give up the ability to fine tune each selection. There is an issue that the Veteran and Fearless buttons should probably be disabled or removed if hiring more than one Kerbal at a time, as is they are ignored if hiring more than 1 Kerbal.