### PR TITLE
Respect KerbalExperienceEnabled setting

### DIFF
--- a/GameData/TRP-Hire/localization/de-de.cfg
+++ b/GameData/TRP-Hire/localization/de-de.cfg
@@ -17,7 +17,7 @@ Localization
 
 		#TRPHire_SelectLevel = Wähle Stufe des Kerbals:
 		#TRPHire_Level5CareerNoExp = Level 5 - Pflichtfeld für Karriere ohne aktive Erfahrungspunkte.
-		#TRPHire_Level5SandboxOrScience = Level 5 - Pflichtfeld für Sandkasten oder Wissenschaftsmodus.
+		#TRPHire_Level5SandboxOrScience = Level 5 - Pflichtfeld für Sandkasten oder Wissenschaftsmodus ohne aktive Erfahrungspunkte.
 
 		#TRPHire_MaxDiscount = Max. Rabatt von <<1>>% erreicht!
 		#TRPHire_NewYear = Fröhliches neues Jahr!

--- a/GameData/TRP-Hire/localization/en-us.cfg
+++ b/GameData/TRP-Hire/localization/en-us.cfg
@@ -17,7 +17,7 @@ Localization
 
 		#TRPHire_SelectLevel = Select Kerbal's Level:
 		#TRPHire_Level5CareerNoExp = Level 5 - Mandatory for Career with no EXP enabled.
-		#TRPHire_Level5SandboxOrScience = Level 5 - Mandatory for Sandbox or Science Mode.
+		#TRPHire_Level5SandboxOrScience = Level 5 - Mandatory for Sandbox or Science Mode with no EXP enabled.
 
 		#TRPHire_MaxDiscount = Max discount of <<1>>% reached!
 		#TRPHire_NewYear = Happy New Year!

--- a/GameData/TRP-Hire/localization/ru.cfg
+++ b/GameData/TRP-Hire/localization/ru.cfg
@@ -18,7 +18,7 @@
 
 		#TRPHire_SelectLevel = Выбрать уровень кербала:
 		#TRPHire_Level5CareerNoExp      = При выключенном опыте кербонавтов только 5 уровень.
-		#TRPHire_Level5SandboxOrScience = Для режимов «Песочница» и «Наука» только 5 уровень.
+		#TRPHire_Level5SandboxOrScience = При выключенном опыте кербонавтов только 5 уровень.
 
 		#TRPHire_MaxDiscount =  Максимальная скидка <<1>>% достигнута!
 		#TRPHire_NewYear = С Новым годом!

--- a/Hire/CustomAstronautComplexUI.cs
+++ b/Hire/CustomAstronautComplexUI.cs
@@ -143,51 +143,48 @@ namespace Hire
 
                 // Hire.Log.Info("PSH :: Status set to Available, courage and stupidity set, fearless trait set.");
 
-                if (KLevel == 1)
-                {
-                    newKerb.flightLog.AddEntry("Training1," + FlightGlobals.GetHomeBodyName());
-                    newKerb.ArchiveFlightLog();
-                    newKerb.experience = 2;
-                    newKerb.experienceLevel = 1;
-                    // Hire.Log.Info("KSI :: Level set to 1.");
-                }
-                if (KLevel == 2)
-                {
-                    newKerb.flightLog.AddEntry("Training2," + FlightGlobals.GetHomeBodyName());
-                    newKerb.ArchiveFlightLog();
-                    newKerb.experience = 8;
-                    newKerb.experienceLevel = 2;
-                    // Hire.Log.Info("KSI :: Level set to 2.");
-                }
-                if (KLevel == 3)
-                {
-                    newKerb.flightLog.AddEntry("Training3," + FlightGlobals.GetHomeBodyName());
-                    newKerb.ArchiveFlightLog();
-                    newKerb.experience = 16;
-                    newKerb.experienceLevel = 3;
-                    // Hire.Log.Info("KSI :: Level set to 3.");
-                }
-                if (KLevel == 4)
-                {
-                    newKerb.flightLog.AddEntry("Training4," + FlightGlobals.GetHomeBodyName());
-                    newKerb.ArchiveFlightLog();
-                    newKerb.experience = 32;
-                    newKerb.experienceLevel = 4;
-                    // Hire.Log.Info("KSI :: Level set to 4.");
-                }
-                if (KLevel == 5)
-                {
-                    newKerb.flightLog.AddEntry("Training5," + FlightGlobals.GetHomeBodyName());
-                    newKerb.ArchiveFlightLog();
-                    newKerb.experience = 64;
-                    newKerb.experienceLevel = 5;
-                    // Hire.Log.Info("KSI :: Level set to 5.");
-                }
                 if (kerExp == false)
                 {
                     newKerb.experience = 9999;
                     newKerb.experienceLevel = 5;
-                    Hire.Log.Info("KSI :: Level set to 5 - Non-Career Mode default.");
+                    Hire.Log.Info("KSI :: Level set to 5 - Kerbal Experince disabled.");
+                }
+                else switch(KLevel)
+                {
+                    case 1:
+                        newKerb.flightLog.AddEntry("Training1," + FlightGlobals.GetHomeBodyName());
+                        newKerb.ArchiveFlightLog();
+                        newKerb.experience = 2;
+                        newKerb.experienceLevel = 1;
+                        // Hire.Log.Info("KSI :: Level set to 1.");
+                        break;
+                    case 2:
+                        newKerb.flightLog.AddEntry("Training2," + FlightGlobals.GetHomeBodyName());
+                        newKerb.ArchiveFlightLog();
+                        newKerb.experience = 8;
+                        newKerb.experienceLevel = 2;
+                        // Hire.Log.Info("KSI :: Level set to 2.");
+                        break;
+                    case 3:
+                        newKerb.flightLog.AddEntry("Training3," + FlightGlobals.GetHomeBodyName());
+                        newKerb.ArchiveFlightLog();
+                        newKerb.experience = 16;
+                        newKerb.experienceLevel = 3;
+                        // Hire.Log.Info("KSI :: Level set to 3.");
+                        break;
+                    case 4:
+                        newKerb.flightLog.AddEntry("Training4," + FlightGlobals.GetHomeBodyName());
+                        newKerb.ArchiveFlightLog();
+                        newKerb.experience = 32;
+                        newKerb.experienceLevel = 4;
+                        // Hire.Log.Info("KSI :: Level set to 4.");
+                        break;
+                    case 5:
+                        newKerb.flightLog.AddEntry("Training5," + FlightGlobals.GetHomeBodyName());
+                        newKerb.ArchiveFlightLog();
+                        newKerb.experience = 64;
+                        newKerb.experienceLevel = 5;
+                        break;
                 }
                 GameEvents.onKerbalAdded.Fire(newKerb); // old gameevent most likely to be used by other mods
                 GameEvents.onKerbalAddComplete.Fire(newKerb); // new gameevent that seems relevant

--- a/Hire/CustomAstronautComplexUI.cs
+++ b/Hire/CustomAstronautComplexUI.cs
@@ -517,6 +517,7 @@ namespace Hire
                         GUILayout.Label(Localizer.Format("#TRPHire_Level5CareerNoExp"));
                     else
                         GUILayout.Label(Localizer.Format("#TRPHire_Level5SandboxOrScience"));
+                    KLevel = 5;
                 }
                 else
                 {

--- a/Hire/CustomAstronautComplexUI.cs
+++ b/Hire/CustomAstronautComplexUI.cs
@@ -159,6 +159,30 @@ namespace Hire
                     newKerb.experienceLevel = 2;
                     // Hire.Log.Info("KSI :: Level set to 2.");
                 }
+                if (KLevel == 3)
+                {
+                    newKerb.flightLog.AddEntry("Training3," + FlightGlobals.GetHomeBodyName());
+                    newKerb.ArchiveFlightLog();
+                    newKerb.experience = 16;
+                    newKerb.experienceLevel = 3;
+                    // Hire.Log.Info("KSI :: Level set to 3.");
+                }
+                if (KLevel == 4)
+                {
+                    newKerb.flightLog.AddEntry("Training4," + FlightGlobals.GetHomeBodyName());
+                    newKerb.ArchiveFlightLog();
+                    newKerb.experience = 32;
+                    newKerb.experienceLevel = 4;
+                    // Hire.Log.Info("KSI :: Level set to 4.");
+                }
+                if (KLevel == 5)
+                {
+                    newKerb.flightLog.AddEntry("Training5," + FlightGlobals.GetHomeBodyName());
+                    newKerb.ArchiveFlightLog();
+                    newKerb.experience = 64;
+                    newKerb.experienceLevel = 5;
+                    // Hire.Log.Info("KSI :: Level set to 5.");
+                }
                 if (kerExp == false)
                 {
                     newKerb.experience = 9999;

--- a/Hire/CustomAstronautComplexUI.cs
+++ b/Hire/CustomAstronautComplexUI.cs
@@ -159,7 +159,7 @@ namespace Hire
                     newKerb.experienceLevel = 2;
                     // Hire.Log.Info("KSI :: Level set to 2.");
                 }
-                if (ACLevel == 5 || kerExp == false)
+                if (kerExp == false)
                 {
                     newKerb.experience = 9999;
                     newKerb.experienceLevel = 5;
@@ -489,14 +489,17 @@ namespace Hire
                 // If statements for level options
                 if (kerExp == false)
                 {
-                    GUILayout.Label(Localizer.Format("#TRPHire_Level5CareerNoExp"));
+                    if (HighLogic.CurrentGame.Mode == Game.Modes.CAREER)
+                        GUILayout.Label(Localizer.Format("#TRPHire_Level5CareerNoExp"));
+                    else
+                        GUILayout.Label(Localizer.Format("#TRPHire_Level5SandboxOrScience"));
                 }
                 else
                 {
                     if (ACLevel == 0) { KLevel = GUILayout.Toolbar(KLevel, KLevelStringsZero); }
-                    if (ACLevel == 0.5) { KLevel = GUILayout.Toolbar(KLevel, KLevelStringsOne); }
-                    if (ACLevel == 1) { KLevel = GUILayout.Toolbar(KLevel, KLevelStringsTwo); }
-                    if (ACLevel == 5) { GUILayout.Label(Localizer.Format("#TRPHire_Level5SandboxOrScience")); }
+                    else if (ACLevel == 0.5) { KLevel = GUILayout.Toolbar(KLevel, KLevelStringsOne); }
+                    else if (ACLevel == 1) { KLevel = GUILayout.Toolbar(KLevel, KLevelStringsTwo); }
+                    else { KLevel = GUILayout.Toolbar(KLevel, KLevelStringsAll); }
                 }
                 GUILayout.EndVertical();
 


### PR DESCRIPTION
As requested in forum thread, do not force new hires at level 5 in sandbox / science modes when player has enabled experience system. Since funds is not active and facilities are maxed, permit choosing freely between levels 0-5.

Address the issue #22 by assigning `KLevel = 5` to correspond to forced level 5 hire when experience system is turned off.  This currently uses standard hiring costs calculation in career mode without experience. Seems like it might be too expensive, though. Will leave final decision on how to balance this to @linuxgurugamer 